### PR TITLE
Make validateOnMount rerun validations when initialValues have changed

### DIFF
--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -363,12 +363,6 @@ export function useFormik<Values extends FormikValues = FormikValues>({
     }
   );
 
-  React.useEffect(() => {
-    if (validateOnMount && isMounted.current === true) {
-      validateFormWithLowPriority(initialValues.current);
-    }
-  }, [validateOnMount, validateFormWithLowPriority]);
-
   const resetForm = React.useCallback(
     (nextState?: Partial<FormikState<Values>>) => {
       const values =
@@ -438,14 +432,20 @@ export function useFormik<Values extends FormikValues = FormikValues>({
 
   React.useEffect(() => {
     if (
-      enableReinitialize &&
       isMounted.current === true &&
       !isEqual(initialValues.current, props.initialValues)
     ) {
       initialValues.current = props.initialValues;
-      resetForm();
+
+      if (enableReinitialize) {
+        resetForm();
+      }
+
+      if (validateOnMount) {
+        validateFormWithLowPriority(initialValues.current);
+      }
     }
-  }, [enableReinitialize, props.initialValues, resetForm]);
+  }, [enableReinitialize, props.initialValues, resetForm, validateOnMount, validateFormWithLowPriority]);
 
   React.useEffect(() => {
     if (


### PR DESCRIPTION
Fixes #2368

Since both `enableReinitialize` and `validateOnMount` effects would need to share the same "update initialValues.current" logic, I've merged them in a single effect, as it seems to me like it's the safest approach.