### PR TITLE
 Fix validation.md

### DIFF
--- a/docs/guides/validation.md
+++ b/docs/guides/validation.md
@@ -242,7 +242,7 @@ export const FieldLevelValidationExample = () => (
           </button>
           {/** Trigger form-level validation
            imperatively */}
-          <button type="button" onClick={() => validateForm().then(() => console.log('blah')))}>
+          <button type="button" onClick={() => validateForm().then(() => console.log('blah'))}>
             Validate All
           </button>
           <button type="submit">Submit</button>


### PR DESCRIPTION
Example code 
https://jaredpalmer.com/formik/docs/guides/validation#manually-triggering-validation

In the example this line breaks the code because of additional parentheses was added at the end
<button type="button" onClick={() => validateForm().then(() => console.log('blah')))}>

It should be
<button type="button" onClick={() => validateForm().then(() => console.log('blah'))}>