### PR TITLE
Remove empty hooks in production build output

### DIFF
--- a/packages/formik/src/Field.tsx
+++ b/packages/formik/src/Field.tsx
@@ -142,8 +142,9 @@ export function Field({
     ...formik
   } = useFormikContext();
 
-  React.useEffect(() => {
-    if (__DEV__) {
+  if (__DEV__) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
       invariant(
         !render,
         `<Field render> has been deprecated and will be removed in future versions of Formik. Please use a child callback function instead. To get rid of this warning, replace <Field name="${name}" render={({field, form}) => ...} /> with <Field name="${name}">{({field, form, meta}) => ...}</Field>`
@@ -163,9 +164,9 @@ export function Field({
         !(render && children && !isEmptyChildren(children)),
         'You should not use <Field render> and <Field children> in the same <Field> component; <Field children> will be ignored'
       );
-    }
-    // eslint-disable-next-line
-  }, []);
+      // eslint-disable-next-line
+    }, []);
+  }
 
   // Register field and field-level validation with parent <Formik>
   const { registerField, unregisterField } = formik;

--- a/packages/formik/src/Formik.tsx
+++ b/packages/formik/src/Formik.tsx
@@ -151,15 +151,16 @@ export function useFormik<Values extends FormikValues = FormikValues>({
   const initialStatus = React.useRef(props.initialStatus);
   const isMounted = React.useRef<boolean>(false);
   const fieldRegistry = React.useRef<FieldRegistry>({});
-  React.useEffect(() => {
-    if (__DEV__) {
+  if (__DEV__) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
       invariant(
         typeof isInitialValid === 'undefined',
         'isInitialValid has been deprecated and will be removed in future versions of Formik. Please use initialErrors or validateOnMount instead.'
       );
-    }
-    // eslint-disable-next-line
-  }, []);
+      // eslint-disable-next-line
+    }, []);
+  }
 
   React.useEffect(() => {
     isMounted.current = true;
@@ -1007,15 +1008,16 @@ export function Formik<
   // This allows folks to pass a ref to <Formik />
   React.useImperativeHandle(innerRef, () => formikbag);
 
-  React.useEffect(() => {
-    if (__DEV__) {
+  if (__DEV__) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    React.useEffect(() => {
       invariant(
         !props.render,
         `<Formik render> has been deprecated and will be removed in future versions of Formik. Please use a child callback function instead. To get rid of this warning, replace <Formik render={(props) => ...} /> with <Formik>{(props) => ...}</Formik>`
       );
-    }
-    // eslint-disable-next-line
-  }, []);
+      // eslint-disable-next-line
+    }, []);
+  }
   return (
     <FormikProvider value={formikbag}>
       {component


### PR DESCRIPTION
`__DEV__` is a constant. It won't change the order of hooks.

![image](https://user-images.githubusercontent.com/5526525/86557455-c2a0d880-bf88-11ea-8936-1e1bbee804bb.png)
