### PR TITLE
fix(docs): Let editUrl point to correct file on Github

### DIFF
--- a/docs/src/pages/users.tsx
+++ b/docs/src/pages/users.tsx
@@ -10,7 +10,7 @@ import { users } from 'users';
 export interface UsersProps {}
 
 const Users: React.FC<UsersProps> = props => {
-  const editUrl = `${siteConfig.repoUrl}/edit/master/website2/src/siteConfig.tsx`;
+  const editUrl = `${siteConfig.repoUrl}/edit/master/docs/src/users.ts`;
   const showcase = users.map(user => (
     <a
       href={user.infoLink}


### PR DESCRIPTION
While browsing the new good-looking website, I discovered that when clicking "Add your company" directs you to a 404 on Github as the paths [got changed recently](https://github.com/formik/formik/commit/d27ed1e434061c1dfc16282bbe5fa742ec473c50#diff-9f9758b3076626327042951f0ed5efc5). This PR solves that issue.